### PR TITLE
changed model loading behavior for internlm

### DIFF
--- a/internlm_model.py
+++ b/internlm_model.py
@@ -48,10 +48,10 @@ class InternlmVLModle():
             
             model = AutoModelForCausalLM.from_pretrained(
                 model_path, 
-                torch_dtype=dtype, 
+                torch_dtype="auto", 
                 trust_remote_code=True,
-                device_map="cuda"
-            ).half().cuda().eval()
+                device_map="auto"
+            ).eval()
 
         else:
             model = model.cpu().float().eval()


### PR DESCRIPTION
I switched the cuda loading behavior for internlm to use auto dtype and auto device_map, which reduces overall memory usage and loading time. This loads directly to the GPU in fp16 now, instead of converting manually which creates a duplicate in memory.